### PR TITLE
Revert "Bump @types/node from 20.14.12 to 22.1.0"

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,7 @@
       },
       "devDependencies": {
         "@types/jest": "28.1.8",
-        "@types/node": "22.1.0",
+        "@types/node": "20.14.12",
         "@typescript-eslint/parser": "7.18.0",
         "@vercel/ncc": "0.38.1",
         "eslint": "8.57.0",
@@ -1680,12 +1680,12 @@
       "dev": true
     },
     "node_modules/@types/node": {
-      "version": "22.1.0",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.1.0.tgz",
-      "integrity": "sha512-AOmuRF0R2/5j1knA3c6G3HOk523Ga+l+ZXltX8SF1+5oqcXijjfTd8fY3XRZqSihEu9XhtQnKYLmkFaoxgsJHw==",
+      "version": "20.14.12",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.14.12.tgz",
+      "integrity": "sha512-r7wNXakLeSsGT0H1AU863vS2wa5wBOK4bWMjZz2wj+8nBx+m5PeIn0k8AloSLpRuiwdRQZwarZqHE4FNArPuJQ==",
       "dev": true,
       "dependencies": {
-        "undici-types": "~6.13.0"
+        "undici-types": "~5.26.4"
       }
     },
     "node_modules/@types/prettier": {
@@ -8799,9 +8799,9 @@
       }
     },
     "node_modules/undici-types": {
-      "version": "6.13.0",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.13.0.tgz",
-      "integrity": "sha512-xtFJHudx8S2DSoujjMd1WeWvn7KKWFRESZTMeL1RptAYERu29D6jphMjjY+vn96jvN3kVPDNxU/E13VTaXj6jg==",
+      "version": "5.26.5",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
+      "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
       "dev": true
     },
     "node_modules/update-browserslist-db": {
@@ -10333,12 +10333,12 @@
       "dev": true
     },
     "@types/node": {
-      "version": "22.1.0",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.1.0.tgz",
-      "integrity": "sha512-AOmuRF0R2/5j1knA3c6G3HOk523Ga+l+ZXltX8SF1+5oqcXijjfTd8fY3XRZqSihEu9XhtQnKYLmkFaoxgsJHw==",
+      "version": "20.14.12",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.14.12.tgz",
+      "integrity": "sha512-r7wNXakLeSsGT0H1AU863vS2wa5wBOK4bWMjZz2wj+8nBx+m5PeIn0k8AloSLpRuiwdRQZwarZqHE4FNArPuJQ==",
       "dev": true,
       "requires": {
-        "undici-types": "~6.13.0"
+        "undici-types": "~5.26.4"
       }
     },
     "@types/prettier": {
@@ -15511,9 +15511,9 @@
       }
     },
     "undici-types": {
-      "version": "6.13.0",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.13.0.tgz",
-      "integrity": "sha512-xtFJHudx8S2DSoujjMd1WeWvn7KKWFRESZTMeL1RptAYERu29D6jphMjjY+vn96jvN3kVPDNxU/E13VTaXj6jg==",
+      "version": "5.26.5",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
+      "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
       "dev": true
     },
     "update-browserslist-db": {

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
   },
   "devDependencies": {
     "@types/jest": "28.1.8",
-    "@types/node": "22.1.0",
+    "@types/node": "20.14.12",
     "@typescript-eslint/parser": "7.18.0",
     "@vercel/ncc": "0.38.1",
     "eslint": "8.57.0",


### PR DESCRIPTION
Reverts freenet-actions/setup-yq#572

Das Upgrade der Types auf Node 22 sollten wir besser erst gemeinsam mit der Action (siehe `action.yml`) machen 